### PR TITLE
Tighten lower bound of base

### DIFF
--- a/acquire.cabal
+++ b/acquire.cabal
@@ -47,4 +47,4 @@ library
   other-modules:
     Acquire.Prelude
   build-depends:
-    base >=4.7 && <5
+    base >=4.9 && <5


### PR DESCRIPTION
...because e.. GHC 7.10.3 would complain:

```
Configuring library for acquire-0.2.0.1..
Preprocessing library for acquire-0.2.0.1..
Building library for acquire-0.2.0.1..

library/Acquire/Prelude.hs:15:8:
    Could not find module ‘Control.Monad.IO.Class’
    It is a member of the hidden package ‘transformers-0.5.5.0@Ci9C7IPl3mKBaaJNc4cl5q’.
    Perhaps you need to add ‘transformers’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘transformers-0.4.2.0@trans_GZTjP9K5WFq01xC9BAGQpF’.
    Perhaps you need to add ‘transformers’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
<<ghc: 241626080 bytes, 151 GCs, 10167576/27203712 avg/max bytes residency (8 samples), 68M in use, 0.001 INIT (0.001 elapsed), 0.061 MUT (0.061 elapsed), 0.287 GC (0.288 elapsed) :ghc>>
```

and this build failure was propagating into e.g. `protoki-core`'s build plans...

I've already revised the affected releases on Hackage:

 - https://hackage.haskell.org/package/acquire-0.1/revisions/
 - https://hackage.haskell.org/package/acquire-0.2/revisions/
 - https://hackage.haskell.org/package/acquire-0.2.0.1/revisions/


